### PR TITLE
GitHub Actions: Reviewdogのworkflow実行に必要なpermissionを追加

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,6 +16,10 @@ on:
 
 jobs:
   lint:
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## 概要

@ikubaku に教えていただいた修正で、こちらにもPRとして提案しました。

> ReviewdogがPRにレビューコメントを追加するために必要なpermissionを追加します。
> 
> - https://github.com/reviewdog/action-eslint/issues/147
> - https://github.com/reviewdog/reviewdog/pull/1051

今回追加したpermissionは以下の用途で必要となります。

- checks: write
	- GitHub ActionsでCheck Runを実行するため
- contents: read
	- リポジトリをクローンするため（変更はしない）
- pull-requests: write
	- Pull Requestsの差分にレビューコメントを作成するため